### PR TITLE
fix(data+seo): stack Cynoia corrigée, nanobrowser-bridge, SearchAction supprimée

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -118,11 +118,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               inLanguage: ['fr', 'en', 'zh', 'ja'],
               author: { '@id': 'https://cherif-diouf.artist-dev.com/#person' },
               publisher: { '@id': 'https://cherif-diouf.artist-dev.com/#person' },
-              potentialAction: {
-                '@type': 'SearchAction',
-                target: 'https://cherif-diouf.artist-dev.com/fr/?q={search_term_string}',
-                'query-input': 'required name=search_term_string',
-              },
             }),
           }}
         />

--- a/src/lib/constants/resume-data.ts
+++ b/src/lib/constants/resume-data.ts
@@ -232,6 +232,12 @@ export const RESUME_DATA: Record<Language, ResumeData> = {
         image: "/assets/projets/my-event-demo.gif"
       },
       {
+        title: "Nanobrowser Bridge",
+        description: "Pont HTTP local pour piloter Nanobrowser (agent IA Chrome) via un LLM local (Ollama). Validation humaine pour les actions sensibles.",
+        tags: ["IA", "Open Source", "Automatisation", "TypeScript"],
+        github: "https://github.com/Maximus203/nanobrowser-bridge",
+      },
+      {
         title: "Archive ESTM",
         description: "Plateforme d'archivage des mémoires avec ancrage Blockchain Ethereum pour l'intégrité.",
         tags: ["Blockchain", "Ethereum", "Archivage"],
@@ -245,8 +251,8 @@ export const RESUME_DATA: Record<Language, ResumeData> = {
       },
       {
         title: "Cynoia Spaces",
-        description: "SaaS de gestion d'espaces collaboratifs. Architecture microservices (Spring Boot, Gateway).",
-        tags: ["Spring Boot", "Microservices", "SaaS"],
+        description: "SaaS de gestion d'espaces collaboratifs. Stack Symfony 6.4 + React 18, déployé avec Docker.",
+        tags: ["Symfony", "React", "SaaS"],
         image: "/assets/projets/cynoia-spaces.gif"
       },
       {
@@ -441,6 +447,12 @@ export const RESUME_DATA: Record<Language, ResumeData> = {
         image: "/assets/projets/my-event-demo.gif"
       },
       {
+        title: "Nanobrowser Bridge",
+        description: "Local HTTP bridge to control Nanobrowser (Chrome AI agent) via a local LLM (Ollama). Human validation for sensitive actions.",
+        tags: ["AI", "Open Source", "Automation", "TypeScript"],
+        github: "https://github.com/Maximus203/nanobrowser-bridge",
+      },
+      {
         title: "Archive ESTM",
         description: "Thesis archiving platform with Ethereum Blockchain anchoring for integrity.",
         tags: ["Blockchain", "Ethereum", "Archiving"],
@@ -454,8 +466,8 @@ export const RESUME_DATA: Record<Language, ResumeData> = {
       },
       {
         title: "Cynoia Spaces",
-        description: "Collaborative space management SaaS. Microservices architecture (Spring Boot, Gateway).",
-        tags: ["Spring Boot", "Microservices", "SaaS"],
+        description: "Collaborative space management SaaS. Symfony 6.4 + React 18 stack, deployed with Docker.",
+        tags: ["Symfony", "React", "SaaS"],
         image: "/assets/projets/cynoia-spaces.gif"
       },
       {
@@ -650,6 +662,12 @@ export const RESUME_DATA: Record<Language, ResumeData> = {
         image: "/assets/projets/my-event-demo.gif"
       },
       {
+        title: "Nanobrowser Bridge",
+        description: "本地HTTP桥接，通过本地LLM（Ollama）控制Nanobrowser（Chrome AI代理）。敏感操作需人工验证。",
+        tags: ["AI", "开源", "自动化", "TypeScript"],
+        github: "https://github.com/Maximus203/nanobrowser-bridge",
+      },
+      {
         title: "Archive ESTM",
         description: "基于以太坊区块链锚定的论文归档平台，确保完整性.",
         tags: ["Blockchain", "Ethereum", "Archivage"],
@@ -663,8 +681,8 @@ export const RESUME_DATA: Record<Language, ResumeData> = {
       },
       {
         title: "Cynoia Spaces",
-        description: "协作空间管理SaaS. 微服务架构 (Spring Boot, Gateway).",
-        tags: ["Spring Boot", "Microservices", "SaaS"],
+        description: "协作空间管理SaaS。Symfony 6.4 + React 18技术栈，使用Docker部署。",
+        tags: ["Symfony", "React", "SaaS"],
         image: "/assets/projets/cynoia-spaces.gif"
       },
       {
@@ -859,6 +877,12 @@ export const RESUME_DATA: Record<Language, ResumeData> = {
         image: "/assets/projets/my-event-demo.gif"
       },
       {
+        title: "Nanobrowser Bridge",
+        description: "ローカルLLM（Ollama）でNanobrowser（Chrome AIエージェント）を制御するローカルHTTPブリッジ。機密アクションには人間の検証が必要。",
+        tags: ["AI", "オープンソース", "自動化", "TypeScript"],
+        github: "https://github.com/Maximus203/nanobrowser-bridge",
+      },
+      {
         title: "Archive ESTM",
         description: "完全性を確保するためのイーサリアムブロックチェーンアンカー付き論文アーカイブプラットフォーム.",
         tags: ["Blockchain", "Ethereum", "Archivage"],
@@ -872,8 +896,8 @@ export const RESUME_DATA: Record<Language, ResumeData> = {
       },
       {
         title: "Cynoia Spaces",
-        description: "コラボレーションスペース管理SaaS. マイクロサービスアーキテクチャ (Spring Boot, Gateway).",
-        tags: ["Spring Boot", "Microservices", "SaaS"],
+        description: "コラボレーションスペース管理SaaS。Symfony 6.4 + React 18構成、Dockerでデプロイ。",
+        tags: ["Symfony", "React", "SaaS"],
         image: "/assets/projets/cynoia-spaces.gif"
       },
       {


### PR DESCRIPTION
Closes #4
Closes #5
Closes #11

## Changements

**#4 — Stack Cynoia Spaces corrigée (crédibilité)**
- Tags : `Spring Boot / Microservices` → `Symfony / React` dans les 4 langues
- Descriptions mises à jour pour refléter le vrai stack (Symfony 6.4 + React 18, Docker)

**#5 — Nanobrowser-bridge ajouté aux projets**
- Carte ajoutée après MyEvent dans les 4 langues (fr/en/zh/ja)
- Image omise : GIF de démo non encore créé (prérequis issue #2 du repo nanobrowser-bridge)

**#11 — SearchAction JSON-LD orpheline supprimée**
- Bloc `potentialAction` retiré du schema WebSite (aucune fonctionnalité de recherche sur le site)

## Test plan

- [x] `npm run build` : 35 pages statiques générées proprement
- [x] Tags Cynoia corrects dans le HTML généré

🤖 Generated with [Claude Code](https://claude.com/claude-code)