### PR TITLE
fix(security+ux): security headers, AdSidebar désactivée, 3-view TODO

### DIFF
--- a/.github/instructions/agent.instructions.md
+++ b/.github/instructions/agent.instructions.md
@@ -26,7 +26,11 @@ applyTo: '**'
 
 ---
 
-### **Fonctionnalité Clé : Le Sélecteur de Vues**
+### **Fonctionnalité Clé : Le Sélecteur de Vues** [TODO — non implémenté, voir issue #9]
+
+> **Status** : reporté. Le store Zustand ne connaît que `theme: 'light' | 'dark'`.
+> Les `profileDescriptions` dans `resume-data.ts` et les types `ProfileType` sont en place
+> mais aucun composant ne switche la présentation. À implémenter dans une future itération.
 
 Dans la barre de navigation, ajoute un composant (par exemple, un groupe de trois boutons ou un switch stylisé) qui permet de basculer entre les trois vues suivantes. Le changement de thème doit se faire par l'ajout d'une classe sur l'élément `<body>` (ex: `theme-frontend`, `theme-backend`) et des modifications dans le CSS.
 

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -15,3 +15,12 @@ RewriteRule ^(.*)$ /$1/index.html [L]
     Header set Cache-Control "public, max-age=31536000, immutable"
   </FilesMatch>
 </IfModule>
+
+# Security headers
+<IfModule mod_headers.c>
+  Header always set X-Frame-Options "SAMEORIGIN"
+  Header always set X-Content-Type-Options "nosniff"
+  Header always set Referrer-Policy "strict-origin-when-cross-origin"
+  Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
+  Header always set Permissions-Policy "camera=(), microphone=(), geolocation=()"
+</IfModule>

--- a/src/app/[lang]/LangLayoutClient.tsx
+++ b/src/app/[lang]/LangLayoutClient.tsx
@@ -66,7 +66,7 @@ export function LangLayoutClient({ lang, children }: LangLayoutClientProps) {
               {children}
             </main>
 
-            {isToolPage && <AdSidebar />}
+            {/* AdSidebar désactivée — publisher ID AdSense non configuré (#12) */}
 
             {isHome && (
               <aside className="hidden lg:block lg:col-span-5 relative">

--- a/src/app/[lang]/LangLayoutClient.tsx
+++ b/src/app/[lang]/LangLayoutClient.tsx
@@ -11,7 +11,6 @@ import LangSwitcher from '@/components/shared/LangSwitcher';
 import ThemeToggle from '@/components/shared/ThemeToggle';
 import IntroAnimation from '@/components/shared/IntroAnimation';
 import ProjectRequestModal from '@/components/shared/ProjectRequestModal';
-import AdSidebar from '@/components/ads/AdSidebar';
 import { useAppStore } from '@/store/store';
 import { getLabels, getResumeData } from '@/lib/i18n';
 import type { Language } from '@/types';
@@ -61,7 +60,8 @@ export function LangLayoutClient({ lang, children }: LangLayoutClientProps) {
           <Navbar lang={lang} labels={labels} />
 
           <div className="max-w-7xl mx-auto px-6 py-8 lg:py-16 grid grid-cols-1 lg:grid-cols-12 gap-12 flex-grow w-full">
-            <main className={`${isFullWidth ? 'lg:col-span-12' : isToolPage ? 'lg:col-span-9' : 'lg:col-span-7'} pt-16 lg:pt-0`}>
+            {/* AdSidebar désactivée (#12) : les pages outils passent en pleine largeur tant que la sidebar ads n'est pas rendue */}
+            <main className={`${isFullWidth ? 'lg:col-span-12' : isToolPage ? 'lg:col-span-12' : 'lg:col-span-7'} pt-16 lg:pt-0`}>
               <DesktopNav lang={lang} labels={labels} />
               {children}
             </main>


### PR DESCRIPTION
Closes #8
Closes #9
Closes #12

## Changements

**#8 — Security headers HTTP**
Ajout dans `public/.htaccess` (déployé via cPanel, mod_headers disponible) :
- `X-Frame-Options: SAMEORIGIN` — protection clickjacking
- `X-Content-Type-Options: nosniff` — protection MIME sniffing
- `Referrer-Policy: strict-origin-when-cross-origin`
- `Strict-Transport-Security: max-age=31536000; includeSubDomains` — HTTPS forcé 1 an
- `Permissions-Policy: camera=(), microphone=(), geolocation=()`

**#12 — AdSidebar désactivée**
`<AdSidebar />` commentée dans `LangLayoutClient` jusqu'à configuration du vrai publisher ID AdSense (Option B de l'issue). Les composants `AdUnit` et `AdSidebar` restent en code.

**#9 — 3-view switcher marqué TODO**
Section du sélecteur de vues dans `agent.instructions.md` marquée `[TODO — non implémenté]` avec état actuel du store. Évite toute confusion future sur une feature promise mais absente.

## Test plan

- [x] `npm run build` : 35 pages statiques générées proprement
- [x] AdSidebar absente du rendu (commentaire en place)
- [ ] Security headers à vérifier via securityheaders.com après déploiement

🤖 Generated with [Claude Code](https://claude.com/claude-code)